### PR TITLE
Fix syntax for conda dependencies

### DIFF
--- a/aml_config/conda_dependencies.yml
+++ b/aml_config/conda_dependencies.yml
@@ -13,8 +13,9 @@ dependencies:
   - numpy=1.11.3
   - pip:
     # Required packages for AzureML execution, history, and data preparation.
-    - --index-url https://azuremldownloads.azureedge.net/python-repository/preview
-    - --extra-index-url https://pypi.python.org/simple
+    # Leave the default for --index-url, that will pull in https://pypi.python.org/simple
+    - --extra-index-url
+    - https://azuremldownloads.azureedge.net/python-repository/preview
     - azureml-requirements
 
     # The API for Azure Machine Learning Model Management Service.


### PR DESCRIPTION
This change will avoid the "no such option --index-url" error message when building the environment with Azure ML Workbench.